### PR TITLE
Refactor: padroniza tratamento de erros da API com controller e service errors

### DIFF
--- a/infra/controller.js
+++ b/infra/controller.js
@@ -1,0 +1,26 @@
+import { InternalServerError, MethodNotAllowedError } from "infra/errors";
+
+function onNoMatchHandler(request, response) {
+  const publicErrorObject = new MethodNotAllowedError();
+  response.status(publicErrorObject.statusCode).json(publicErrorObject);
+}
+
+function onErrorHandler(error, request, response) {
+  const publicErrorObject = new InternalServerError({
+    statusCode: error.statusCode,
+    cause: error,
+  });
+
+  console.error(publicErrorObject);
+
+  response.status(publicErrorObject.statusCode).json(publicErrorObject);
+}
+
+const controller = {
+  errorHandlers: {
+    onNoMatch: onNoMatchHandler,
+    onError: onErrorHandler,
+  },
+};
+
+export default controller;

--- a/infra/database.js
+++ b/infra/database.js
@@ -1,23 +1,24 @@
 import { Client } from "pg";
+import { ServiceError } from "infra/errors";
 
-// Executa uma query e garante o encerramento da conexão.
 async function query(queryObject) {
   let client;
 
   try {
     client = await getNewClient();
-    return await client.query(queryObject);
+    const result = await client.query(queryObject);
+    return result;
   } catch (error) {
-    console.error("\nErro ao executar query em database.js:");
-    console.error(error);
-    throw error;
+    const serviceErrorObject = new ServiceError({
+      message: "Erro na conexão com Banco ou na Query.",
+      cause: error,
+    });
+    throw serviceErrorObject;
   } finally {
-    // Evita erro caso a conexão não tenha sido criada.
     await client?.end();
   }
 }
 
-// Cria e conecta um novo client com base nas variáveis de ambiente.
 async function getNewClient() {
   const client = new Client({
     host: process.env.POSTGRES_HOST,
@@ -32,7 +33,6 @@ async function getNewClient() {
   return client;
 }
 
-// Define a configuração de SSL conforme o ambiente.
 function getSSLValues() {
   if (process.env.POSTGRES_CA) {
     return {
@@ -40,7 +40,7 @@ function getSSLValues() {
     };
   }
 
-  return process.env.NODE_ENV === "production";
+  return process.env.NODE_ENV === "production" ? true : false;
 }
 
 const database = {

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -1,23 +1,13 @@
-// Classe de erro customizado para representar falhas internas do servidor (HTTP 500)
-// A ideia é padronizar erros inesperados sem expor detalhes sensíveis para o usuário
 export class InternalServerError extends Error {
-  constructor({ cause }) {
-    // Chama o construtor da classe nativa Error:
-    // - define uma mensagem genérica (segura para o usuário)
-    // - armazena o erro original em "cause" para debug interno
+  constructor({ cause, statusCode }) {
     super("Um erro interno não esperado aconteceu.", {
       cause,
     });
-    //Subscreve a propiedade name
     this.name = "InternalServerError";
     this.action = "Entre em contato com o suporte.";
-    this.statusCode = 500;
+    this.statusCode = statusCode || 500;
   }
 
-  // Controla a serialização do erro na API:
-  // - Error padrão vira {} porque suas propriedades não são enumeráveis
-  // - toJSON define explicitamente o formato da resposta
-  // - retorno apenas a mensagem para não expor detalhes internos (stack, cause)
   toJSON() {
     return {
       name: this.name,
@@ -28,25 +18,35 @@ export class InternalServerError extends Error {
   }
 }
 
-// Classe de erro customizado para representar falhas internas do servidor (HTTP 500)
-// A ideia é padronizar erros inesperados sem expor detalhes sensíveis para o usuário
+export class ServiceError extends Error {
+  constructor({ cause, message }) {
+    super(message || "Serviço indisponível no momento.", {
+      cause,
+    });
+    this.name = "ServiceError";
+    this.action = "Verifique se o serviço está disponível.";
+    this.statusCode = 503;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}
+
 export class MethodNotAllowedError extends Error {
   constructor() {
-    // Chama o construtor da classe nativa Error:
-    // - define uma mensagem genérica (segura para o usuário)
-    // - armazena o erro original em "cause" para debug interno
     super("Método não permitido para este endpoint.");
-    //Subscreve a propiedade name
     this.name = "MethodNotAllowedError";
     this.action =
       "Verifique se o método HTTP enviado é válido para este endpoint.";
     this.statusCode = 405;
   }
 
-  // Controla a serialização do erro na API:
-  // - Error padrão vira {} porque suas propriedades não são enumeráveis
-  // - toJSON define explicitamente o formato da resposta
-  // - retorno apenas a mensagem para não expor detalhes internos (stack, cause)
   toJSON() {
     return {
       name: this.name,

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -27,3 +27,32 @@ export class InternalServerError extends Error {
     };
   }
 }
+
+// Classe de erro customizado para representar falhas internas do servidor (HTTP 500)
+// A ideia é padronizar erros inesperados sem expor detalhes sensíveis para o usuário
+export class MethodNotAllowedError extends Error {
+  constructor() {
+    // Chama o construtor da classe nativa Error:
+    // - define uma mensagem genérica (segura para o usuário)
+    // - armazena o erro original em "cause" para debug interno
+    super("Método não permitido para este endpoint.");
+    //Subscreve a propiedade name
+    this.name = "MethodNotAllowedError";
+    this.action =
+      "Verifique se o método HTTP enviado é válido para este endpoint.";
+    this.statusCode = 405;
+  }
+
+  // Controla a serialização do erro na API:
+  // - Error padrão vira {} porque suas propriedades não são enumeráveis
+  // - toJSON define explicitamente o formato da resposta
+  // - retorno apenas a mensagem para não expor detalhes internos (stack, cause)
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "dotenv": "16.4.5",
         "dotenv-expand": "11.0.6",
         "next": "14.2.5",
+        "next-connect": "1.0.0",
         "node-pg-migrate": "7.6.1",
         "pg": "8.12.0",
         "react": "18.3.1",
@@ -2099,6 +2100,12 @@
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
@@ -9170,6 +9177,19 @@
         }
       }
     },
+    "node_modules/next-connect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-connect/-/next-connect-1.0.0.tgz",
+      "integrity": "sha512-FeLURm9MdvzY1SDUGE74tk66mukSqL6MAzxajW7Gqh6DZKBZLrXmXnGWtHJZXkfvoi+V/DUe9Hhtfkl4+nTlYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsconfig/node16": "^1.0.3",
+        "regexparam": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
@@ -10212,6 +10232,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexparam": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-2.0.2.tgz",
+      "integrity": "sha512-A1PeDEYMrkLrfyOwv2jwihXbo9qxdGD3atBYQA9JJgreAx8/7rC6IUkWOw2NQlOxLp2wL0ifQbh1HuidDfYA6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "dotenv": "16.4.5",
     "dotenv-expand": "11.0.6",
     "next": "14.2.5",
+    "next-connect": "1.0.0",
     "node-pg-migrate": "7.6.1",
     "pg": "8.12.0",
     "react": "18.3.1",

--- a/pages/api/v1/migrations/index.js
+++ b/pages/api/v1/migrations/index.js
@@ -1,92 +1,54 @@
-// Importa a função que executa migrations usando o banco PostgreSQL
-// Essa lib sabe ler arquivos de migration e controlar o que já rodou
+import { createRouter } from "next-connect";
 import migrationRunner from "node-pg-migrate";
-
-// Importa a função resolve para montar caminhos de pastas
-// Evita problemas de path entre sistemas (Windows, Mac, Linux)
 import { resolve } from "node:path";
 
-// Importa o módulo de banco de dados que você criou
-// Ele fornece getNewClient() para abrir conexões com o banco
+import controller from "infra/controller.js";
 import database from "infra/database.js";
 
-// Função principal do endpoint /api/v1/migrations
-// request  -> representa a requisição HTTP (método, headers, etc)
-// response -> representa a resposta HTTP que será enviada
-export default async function migrations(request, response) {
-  const allowedMethods = ["GET", "POST"];
-  if (!allowedMethods.includes(request.method)) {
-    return response.status(405).json({
-      error: `Method "${request.method}"not allowed`,
-    });
+const router = createRouter();
+
+const defaultMigrationOptions = {
+  dryRun: true,
+  dir: resolve("infra", "migrations"),
+  direction: "up",
+  verbose: true,
+  migrationsTable: "pgmigrations",
+};
+
+router.get(getHandler);
+router.post(postHandler);
+
+export default router.handler(controller.errorHandlers);
+
+async function getHandler(request, response) {
+  const pendingMigrations = await runMigrations();
+  response.status(200).json(pendingMigrations);
+}
+
+async function postHandler(request, response) {
+  const migratedMigrations = await runMigrations({ dryRun: false });
+
+  if (migratedMigrations.length > 0) {
+    return response.status(201).json(migratedMigrations);
   }
 
+  return response.status(200).json(migratedMigrations);
+}
+
+async function runMigrations({ dryRun } = defaultMigrationOptions) {
   let dbClient;
+
   try {
-    // Cria uma nova conexão com o banco de dados
-    // Essa conexão será usada pelo node-pg-migrate
     dbClient = await database.getNewClient();
 
-    // Configuração base das migrations
-    // Essas opções serão usadas tanto no GET quanto no POST
-    const defaultMigrationOptions = {
-      // Cliente de banco que o node-pg-migrate vai usar
-      dbClient: dbClient,
-
-      // dryRun = true significa:
-      // "simula as migrations, mas NÃO aplica no banco"
-      dryRun: true,
-
-      // Diretório onde estão os arquivos de migration
-      dir: resolve("infra", "migrations"),
-
-      // Direção das migrations
-      // "up" = aplicar migrations pendentes
-      direction: "up",
-
-      // verbose = true mostra logs detalhados
-      verbose: true,
-
-      // Nome da tabela que controla quais migrations já rodaram
-      migrationsTable: "pgmigrations",
-    };
-
-    // Se o método HTTP for GET
-    if (request.method === "GET") {
-      // Executa o migrationRunner em modo dryRun
-      // Isso retorna apenas as migrations pendentes
-      const pendingMigrations = await migrationRunner(defaultMigrationOptions);
-
-      // Retorna status 200 (OK) com a lista de migrations pendentes
-      return response.status(200).json(pendingMigrations);
-
-      // Se o método HTTP for POST
-    } else if (request.method === "POST") {
-      // Executa o migrationRunner de verdade (dryRun = false)
-      // Aqui as migrations são aplicadas no banco
-      const migratedMigrations = await migrationRunner({
-        ...defaultMigrationOptions,
-        dryRun: false,
-      });
-
-      // Se alguma migration foi aplicada
-      if (migratedMigrations.length > 0) {
-        // Retorna 201 (Created)
-        // Indica que algo novo foi criado/modificado no servidor
-        return response.status(201).json(migratedMigrations);
-      }
-
-      // Se nenhuma migration foi aplicada
-      // Retorna 200 (OK) com array vazio
-      return response.status(200).json(migratedMigrations);
-
-      // Se o método HTTP não for GET nem POST
-    }
-  } catch (error) {
-    console.error(error);
-    throw error;
+    return await migrationRunner({
+      ...defaultMigrationOptions,
+      dbClient,
+      dryRun,
+    });
   } finally {
-    // Fecha a conexão com o banco
-    await dbClient.end();
+    if (dbClient) {
+      await dbClient.end();
+    }
   }
 }

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -1,65 +1,41 @@
 //.   pega esse objeto dentro do next connect
 import { createRouter } from "next-connect";
+import controller from "infra/controller.js";
 import database from "infra/database.js";
-// Importo só o InternalServerError porque este arquivo só trata erro 500.
-// Evito importar "errors" inteiro para manter claro quais erros são usados aqui
-// e evitar dependências desnecessárias.
-import { InternalServerError, MethodNotAllowedError } from "infra/errors";
 
 const router = createRouter();
 
 router.get(getHandler);
 
-export default router.handler({
-  onNoMatch: onNoMatchHandler,
-  onError: onErrorHandler,
-});
-
-function onNoMatchHandler(request, response) {
-  const publicErrorObject = new MethodNotAllowedError();
-  response.status(publicErrorObject.statusCode).json(publicErrorObject);
-}
-
-function onErrorHandler(error, request, response) {
-  const publicErrorObject = new InternalServerError({
-    cause: error,
-  });
-
-  console.log("\n Erro dentro do catch do next-connect:");
-  console.error(publicErrorObject);
-
-  response.status(500).json(publicErrorObject);
-}
+export default router.handler(controller.errorHandlers);
 
 async function getHandler(request, response) {
-  //  Data de atualização da API
   const updatedAt = new Date().toISOString();
 
-  // Pergunta ao Postgress QUAL É A VERSÃO
   const databaseVersionResult = await database.query("SHOW server_version;");
-  const databaseVersion = databaseVersionResult.rows[0].server_version;
+  const databaseVersionValue = databaseVersionResult.rows[0].server_version;
 
-  // Pergunta ao Postgress QUAL É O MAXIMO DE CONEXÕES
-  const maxConnectionsResult = await database.query("SHOW max_connections;");
-  const maxConnections = Number(maxConnectionsResult.rows[0].max_connections);
+  const databaseMaxConnectionsResult = await database.query(
+    "SHOW max_connections;",
+  );
+  const databaseMaxConnectionsValue =
+    databaseMaxConnectionsResult.rows[0].max_connections;
 
-  //pergunta ao Postgress QUANTAS CONEXÕES ESTÃO SENDO USADAS AGORA
-  const usedConnectionResult = await database.query(`
-    SELECT count (*)
-    FROM pg_stat_activity
-    WHERE datname = current_Database();
-    `);
+  const databaseName = process.env.POSTGRES_DB;
+  const databaseOpenedConnectionsResult = await database.query({
+    text: "SELECT count(*)::int FROM pg_stat_activity WHERE datname = $1;",
+    values: [databaseName],
+  });
+  const databaseOpenedConnectionsValue =
+    databaseOpenedConnectionsResult.rows[0].count;
 
-  const usedConnections = Number(usedConnectionResult.rows[0].count);
-
-  // Retorno do JSON
   response.status(200).json({
     updated_at: updatedAt,
     dependencies: {
       database: {
-        version: databaseVersion,
-        max_connections: maxConnections,
-        used_connections: usedConnections,
+        version: databaseVersionValue,
+        max_connections: parseInt(databaseMaxConnectionsValue),
+        used_connections: databaseOpenedConnectionsValue,
       },
     },
   });

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -1,52 +1,66 @@
+//.   pega esse objeto dentro do next connect
+import { createRouter } from "next-connect";
 import database from "infra/database.js";
 // Importo só o InternalServerError porque este arquivo só trata erro 500.
 // Evito importar "errors" inteiro para manter claro quais erros são usados aqui
 // e evitar dependências desnecessárias.
-import { InternalServerError } from "infra/errors";
+import { InternalServerError, MethodNotAllowedError } from "infra/errors";
 
-async function status(request, response) {
-  try {
-    //  Data de atualização da API
-    const updatedAt = new Date().toISOString();
+const router = createRouter();
 
-    // Pergunta ao Postgress QUAL É A VERSÃO
-    const databaseVersionResult = await database.query("SHOW server_version;");
-    const databaseVersion = databaseVersionResult.rows[0].server_version;
+router.get(getHandler);
 
-    // Pergunta ao Postgress QUAL É O MAXIMO DE CONEXÕES
-    const maxConnectionsResult = await database.query("SHOW max_connections;");
-    const maxConnections = Number(maxConnectionsResult.rows[0].max_connections);
+export default router.handler({
+  onNoMatch: onNoMatchHandler,
+  onError: onErrorHandler,
+});
 
-    //pergunta ao Postgress QUANTAS CONEXÕES ESTÃO SENDO USADAS AGORA
-    const usedConnectionResult = await database.query(`
+function onNoMatchHandler(request, response) {
+  const publicErrorObject = new MethodNotAllowedError();
+  response.status(publicErrorObject.statusCode).json(publicErrorObject);
+}
+
+function onErrorHandler(error, request, response) {
+  const publicErrorObject = new InternalServerError({
+    cause: error,
+  });
+
+  console.log("\n Erro dentro do catch do next-connect:");
+  console.error(publicErrorObject);
+
+  response.status(500).json(publicErrorObject);
+}
+
+async function getHandler(request, response) {
+  //  Data de atualização da API
+  const updatedAt = new Date().toISOString();
+
+  // Pergunta ao Postgress QUAL É A VERSÃO
+  const databaseVersionResult = await database.query("SHOW server_version;");
+  const databaseVersion = databaseVersionResult.rows[0].server_version;
+
+  // Pergunta ao Postgress QUAL É O MAXIMO DE CONEXÕES
+  const maxConnectionsResult = await database.query("SHOW max_connections;");
+  const maxConnections = Number(maxConnectionsResult.rows[0].max_connections);
+
+  //pergunta ao Postgress QUANTAS CONEXÕES ESTÃO SENDO USADAS AGORA
+  const usedConnectionResult = await database.query(`
     SELECT count (*)
     FROM pg_stat_activity
     WHERE datname = current_Database();
     `);
 
-    const usedConnections = Number(usedConnectionResult.rows[0].count);
+  const usedConnections = Number(usedConnectionResult.rows[0].count);
 
-    // Retorno do JSON
-    response.status(200).json({
-      updated_at: updatedAt,
-      dependencies: {
-        database: {
-          version: databaseVersion,
-          max_connections: maxConnections,
-          used_connections: usedConnections,
-        },
+  // Retorno do JSON
+  response.status(200).json({
+    updated_at: updatedAt,
+    dependencies: {
+      database: {
+        version: databaseVersion,
+        max_connections: maxConnections,
+        used_connections: usedConnections,
       },
-    });
-  } catch (error) {
-    const publicErrorObject = new InternalServerError({
-      cause: error,
-    });
-
-    console.log("\n Erro dentro do catch do controller:");
-    console.error(publicErrorObject);
-
-    response.status(500).json(publicErrorObject);
-  }
+    },
+  });
 }
-
-export default status;

--- a/tests/integration/api/v1/status/post.test.js
+++ b/tests/integration/api/v1/status/post.test.js
@@ -1,0 +1,26 @@
+import orchestrator from "tests/orchestrator.js";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+});
+
+describe("POST /api/v1/status", () => {
+  describe("Anonymous user", () => {
+    test("Retrieving current system status", async () => {
+      const response = await fetch("http://localhost:3000/api/v1/status", {
+        method: "POST",
+      });
+      expect(response.status).toBe(405);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "MethodNotAllowedError",
+        message: "Método não permitido para este endpoint.",
+        action:
+          "Verifique se o método HTTP enviado é válido para este endpoint.",
+        status_code: 405,
+      });
+    });
+  });
+});

--- a/tests/unit/infra/controller.test.js
+++ b/tests/unit/infra/controller.test.js
@@ -1,0 +1,36 @@
+import controller from "infra/controller.js";
+import { ServiceError } from "infra/errors.js";
+
+describe("infra/controller", () => {
+  test("returns 503 when receiving a ServiceError", () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const response = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    const error = new ServiceError({
+      message: "Erro na conexao com Banco ou na Query.",
+      cause: new Error("database is down"),
+    });
+
+    controller.errorHandlers.onError(error, {}, response);
+
+    expect(response.status).toHaveBeenCalledWith(503);
+
+    const publicErrorObject = response.json.mock.calls[0][0];
+
+    expect(publicErrorObject.name).toBe("InternalServerError");
+    expect(publicErrorObject.statusCode).toBe(503);
+    expect(publicErrorObject.toJSON()).toEqual({
+      name: "InternalServerError",
+      message: "Um erro interno não esperado aconteceu.",
+      action: "Entre em contato com o suporte.",
+      status_code: 503,
+    });
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/tests/unit/infra/database.test.js
+++ b/tests/unit/infra/database.test.js
@@ -1,0 +1,36 @@
+const mockConnect = jest.fn();
+const mockQuery = jest.fn();
+const mockEnd = jest.fn();
+
+jest.mock("pg", () => ({
+  Client: jest.fn().mockImplementation(() => ({
+    connect: mockConnect,
+    query: mockQuery,
+    end: mockEnd,
+  })),
+}));
+
+import database from "infra/database.js";
+
+describe("infra/database", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("throws ServiceError when pg query fails", async () => {
+    mockConnect.mockResolvedValue();
+    mockQuery.mockRejectedValue(new Error("query failed"));
+    mockEnd.mockResolvedValue();
+
+    await expect(database.query("SELECT 1")).rejects.toMatchObject({
+      name: "ServiceError",
+      message: "Erro na conexão com Banco ou na Query.",
+      action: "Verifique se o serviço está disponível.",
+      statusCode: 503,
+    });
+
+    expect(mockConnect).toHaveBeenCalledTimes(1);
+    expect(mockQuery).toHaveBeenCalledWith("SELECT 1");
+    expect(mockEnd).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Padroniza os Controllers dos endpoints /migrations e /status.
Adiciona 2 novos erros customizados: MethodNotAllowedError e ServiceError.
Faz o InternalServerError aceitar injeção do statusCode